### PR TITLE
Fix logic to accept billets with dueDate beyond 2025-02-21

### DIFF
--- a/lib/boletoUtils.js
+++ b/lib/boletoUtils.js
@@ -407,7 +407,7 @@ var Datas = (function() {
 		}
 
 		if(!validarData(_vencimento)) {
-			throw new Error('O ano do documento deve ser maior que 1997 e menor que 2024');
+			throw new Error('O ano do documento deve ser maior que 1997 e menor que 2030');
 		}
 
 		this._vencimento = removerHoras(_vencimento);
@@ -588,9 +588,9 @@ var Boleto = (function() {
 		var vencimento = this.getDatas().getVencimento(),
 			diferencaEmDias = (vencimento - DATA_BASE) / (1000 * 60 * 60 * 24);
 
-		if(diferencaEmDias > 9999) {
-			throw new Error('Data fora do formato aceito');
-		}
+    if (diferencaEmDias >= 10000) {
+      diferencaEmDias = diferencaEmDias - 9000;
+    }
 
 		return Math.floor(diferencaEmDias).toString();
 	}
@@ -661,9 +661,9 @@ var Boleto = (function() {
 			throw new Error('Valor deve ser maior ou igual a zero');
 		}
 
-		if(_valorBoleto > 99999999.99) {
-			throw new Error('Valor deve ser menor do que noventa e nove milhoes');
-		}
+    if (diferencaEmDias >= 10000) {
+      diferencaEmDias = diferencaEmDias - 9000;
+    }
 
 		this._valorBoleto = _valorBoleto;
 		return this;


### PR DESCRIPTION
Please consider this PR.

According FEBRABAN the "Fator Vencimento" should be reseted to 1000 when it reaches this specific date.
This results in a bad generated barcode, that can have more than 44char, then throws an error. this logic also fixes the error occurs on the "gerarPDF", that avoid the generation of the PDF file
